### PR TITLE
Add cmd line styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It comes with a single alias, `replet`, which opens the REPLet console. From the
 
 Once you have the console open, you can type `usage` within the console for the extra commands which REPLet comes with, in addition to executing code.
 
-By default, adds `recho(msg)`, `rcecho(msg)` etc to allow for easy c/d/h/echoing directly to the console. If this covers over functions you already have and want to use in the console, use `addEchos false` in the REPLet console's command line.
+By default, adds `recho(msg)`, `rcecho(msg)` etc to allow for easy c/d/h/echoing directly to the console. Also adds rdisplay, which works like display() but prints to the REPLet console. If this covers over functions you already have and want to use in the console, use `addEchos false` in the REPLet console's command line.
 
 ## Why REPLet?
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ It comes with a single alias, `replet`, which opens the REPLet console. From the
 Once you have the console open, you can type `usage` within the console for the extra commands which REPLet comes with, in addition to executing code.
 
 By default, adds `recho(msg)`, `rcecho(msg)` etc to allow for easy c/d/h/echoing directly to the console. If this covers over functions you already have and want to use in the console, use `addEchos false` in the REPLet console's command line.
+
+## Why REPLet?
+
+REPL is an acronym which stands for `Read Execute Print Loop` and is the term for interactive code runners like this. So I squashed it together with Mudlet to make REPLet.

--- a/src/scripts/REPLet/code.lua
+++ b/src/scripts/REPLet/code.lua
@@ -37,7 +37,7 @@ function REPLet.load()
     REPLet.config = table.update(REPLet.config, cfg)
   end
 end
-local orecho, orcecho, ordecho, orhecho = recho, rcecho, rdecho, rhecho
+local orecho, orcecho, ordecho, orhecho, ordisplay = recho, rcecho, rdecho, rhecho, rdisplay
 
 function REPLet.addEchos()
   if not REPLet.config.addEchos then return end
@@ -71,11 +71,15 @@ function REPLet.addEchos()
     REPLet.console:hecho(msg)
     REPLet.console:setFgColor(REPLet.config.fgColor)
   end
+
+  function rdisplay(...)
+    REPLet.console:display(...)
+  end
 end
 
 function REPLet.removeEchos()
   if not REPLet.config.addEchos then return end
-  recho, rcecho, rdecho, rhecho = orecho, orcecho, ordecho, orhecho
+  recho, rcecho, rdecho, rhecho, rdisplay = orecho, orcecho, ordecho, orhecho, ordisplay
 end
 
 function REPLet.error(...)
@@ -129,7 +133,7 @@ function REPLet.usage()
   echo("  * turns on or off autoWrap. example:")
   echo("  * autoWrap true")
   echo("* addEchos <true or false>")
-  echo("  * if true, adds recho, rcecho, rdecho, and rhecho functions to echo to the REPLet console.")
+  echo("  * if true, adds recho, rcecho, rdecho, rhecho, and rdisplay functions to echo to the REPLet console.")
   echo("  * Only available in the console. example:")
   echo("  * addEchos true")
   echo("* usage")

--- a/src/scripts/REPLet/code.lua
+++ b/src/scripts/REPLet/code.lua
@@ -6,6 +6,8 @@ REPLet.config = REPLet.config or {
   fgColor = "lime_green",
   color = "black",
   cmdColor = "cyan",
+  borderColor = "lime_green",
+  borderThickness = 1,
   addEchos = true,
 }
 
@@ -94,6 +96,8 @@ function REPLet.usage()
   echo("REPLet comes with a few built in commands you can run inside the REPLet console only")
   echo("* clear")
   echo("  * clears the window and prints the intro")
+  echo("* config")
+  echo("  * prints the current REPLet configuration to the REPLet console.")
   echo("* exit")
   echo("  * closes the REPLet window")
   echo("* font <font name>")
@@ -115,6 +119,12 @@ function REPLet.usage()
   echo("* fgColor <color name>")
   echo("  * sets the text color for the output in the REPLet console. example:")
   echo("  * fgColor lime_green")
+  echo("* borderColor <color name>")
+  echo("  * sets the color for the border around the input line. example:")
+  echo("  * borderColor lime_green")
+  echo("* borderThickness <number>")
+  echo("  * thickness of the border around the input line, in pixels. example:")
+  echo("  * borderThickness 1")
   echo("* autoWrap <true or false>")
   echo("  * turns on or off autoWrap. example:")
   echo("  * autoWrap true")
@@ -125,6 +135,23 @@ function REPLet.usage()
   echo("* usage")
   echo("  * prints this message")
   echo(REPLet.prompt)
+end
+
+function REPLet.styleCmdline()
+  local borderThickness = REPLet.config.borderThickness
+  local borderColor = Geyser.Color.hex(REPLet.config.borderColor)
+  local fontSize = REPLet.config.fontSize
+  local font = REPLet.config.font
+  local bgColor = REPLet.config.color
+  local cmdColor = Geyser.Color.hex(REPLet.config.cmdColor)
+  local style = f[[
+    border: {borderThickness}px solid {borderColor};
+    font: {fontSize}pt "{font}";
+    background-color: {bgColor};
+    color: {cmdColor}
+  ]]
+  style = "QPlainTextEdit {" .. style .. "}" -- not included in the f call due to the {}
+  setCmdLineStyleSheet(REPLet.console.name, style)
 end
 
 function REPLet.run(codeString)
@@ -142,12 +169,19 @@ function REPLet.run(codeString)
     return
   end
 
+  if codeString == "config" then
+    REPLet.console:display(REPLet.config)
+    REPLet.console:echo(REPLet.prompt)
+    return
+  end
+
   local fontSize = tonumber(codeString:match("^fontSize (%d+)$"))
   if fontSize then
     REPLet.config.fontSize = fontSize
     REPLet.console:setFontSize(fontSize)
     REPLet.console:echo("Set fontSize to: " .. fontSize .. "\n")
     REPLet.console:echo(REPLet.prompt)
+    REPLet.styleCmdline()
     return
   end
 
@@ -157,6 +191,7 @@ function REPLet.run(codeString)
     REPLet.console:setFont(font)
     REPLet.console:echo("Set font to: " .. font .. "\n")
     REPLet.console:echo(REPLet.prompt)
+    REPLet.styleCmdline()
     return
   end
 
@@ -205,11 +240,30 @@ function REPLet.run(codeString)
     return
   end
 
+  local borderColor = codeString:match("^borderColor (.+)")
+  if borderColor then
+    REPLet.config.borderColor = borderColor
+    REPLet.styleCmdline()
+    REPLet.console:echo("Set borderColor to: " .. borderColor .. "\n")
+    REPLet.console:echo(REPLet.prompt)
+    return
+  end
+
+  local borderThickness = tonumber(codeString:match("^borderThickness (%d+)"))
+  if borderThickness then
+    REPLet.config.borderThickness = borderThickness
+    REPLet.styleCmdline()
+    REPLet.console:echo("Set borderThickness to: " .. borderThickness .. "\n")
+    REPLet.console:echo(REPLet.prompt)
+    return
+  end
+
   local CMDColor = codeString:match("^cmdColor (.+)")
   if CMDColor then
     REPLet.config.cmdColor = CMDColor
     REPLet.console:echo("Set cmdColor to: " .. CMDColor .. "\n")
     REPLet.console:echo(REPLet.prompt)
+    REPLet.styleCmdline()
     return
   end
 
@@ -219,6 +273,7 @@ function REPLet.run(codeString)
     REPLet.console:setColor(color)
     REPLet.console:echo("Set color to: " .. color .. "\n")
     REPLet.console:echo(REPLet.prompt)
+    REPLet.styleCmdline()
     return
   end
 
@@ -297,6 +352,7 @@ function REPLet.init()
   }, REPLet.container)
   REPLet.console:setFgColor(REPLet.config.fgColor)
   REPLet.console:setCmdAction(REPLet.run)
+  REPLet.styleCmdline()
   REPLet.clear()
   REPLet.container:show()
 end


### PR DESCRIPTION
This change adds a configurable border around the cmd line, and styles the cmd line to match the rest of the REPLet configuration.

Also adds rdisplay function to make displaying to the REPLet console easier.